### PR TITLE
v9999.8 - Fix bookingform.php missing Tickets

### DIFF
--- a/events-manager.php
+++ b/events-manager.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name:    Events Manager (ICTU WP corrections)
-Version: 9999.7
+Version: 9999.8
 Plugin URI: https://wp-events-plugin.com
 Description: Event registration and booking management for WordPress. Recurring events, locations, webinars, google maps, rss, ical, booking registration and more!
 Author: Pixelite
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
 // Setting constants
-define('EM_VERSION', '9999.7'); //self expanatory, although version currently may not correspond directly with published version number. until 6.0 we're stuck updating 5.999.x
+define('EM_VERSION', '9999.8'); //self expanatory, although version currently may not correspond directly with published version number. until 6.0 we're stuck updating 5.999.x
 define('EM_PRO_MIN_VERSION', '3.0'); //self expanatory
 define('EM_PRO_MIN_VERSION_CRITICAL', '3.0'); //self expanatory
 define('EM_DIR', dirname( __FILE__ )); //an absolute path to this directory

--- a/templates/placeholders/bookingform.php
+++ b/templates/placeholders/bookingform.php
@@ -21,10 +21,9 @@
 
 global $EM_Notices;
 
-// @NOTE: GC override
+// @NOTE: GC override: add inline `hidden` to tickets section?
 // ------------------
 $gc_show_tickets_section = function_exists( 'gc_show_tickets_section' ) ? gc_show_tickets_section() : false;
-$show_tickets            = $gc_show_tickets_section;
 // ------------------
 // END: GC override
 
@@ -70,8 +69,8 @@ do_action('em_booking_form_start', $EM_Event); // do not delete
 				 */
 				?>
 				<?php do_action('em_booking_form_before_tickets_section', $EM_Event, $EM_Booking); // do not delete ?>
-				<?php /* @NOTE: GC override */ if ( $gc_show_tickets_section ) : ?>
-				<section class="em-booking-form-section-tickets" id="em-booking-form-section-tickets-<?php echo $id; ?>">
+				<?php /* @NOTE: GC override: add inline `hidden` */ ?>
+				<section <?php if ( !$gc_show_tickets_section ) { echo 'hidden'; } ?> class="em-booking-form-section-tickets" id="em-booking-form-section-tickets-<?php echo $id; ?>">
 					<?php if( get_option('dbem_bookings_header_tickets') ): ?>
 				    <h3 class="em-booking-section-title em-booking-form-tickets-title"><?php echo esc_html(get_option('dbem_bookings_header_tickets')); ?></h3>
 					<?php endif; ?>
@@ -95,7 +94,6 @@ do_action('em_booking_form_start', $EM_Event); // do not delete
 					?>
 					</div>
 				</section>
-				<?php /* @NOTE: END GC override */ endif; ?>
 				<?php do_action('em_booking_form_after_tickets_section', $EM_Event, $EM_Booking); // do not delete ?>
 
 				<?php if( $can_book ): ?>


### PR DESCRIPTION
Now ignoring core `$show_tickets` and hiding the Tickets Section _only visually_ (with a `hidden` attribute). This way the Ticket inputs are still rendered and passed on submit.

This fixes a bug ("Selecteer tenminste 1 ticket!").

`bookingform.php` is updated in this plugin, but we have an (exact) copy in the NPR theme. We should discuss if we want to have a copy there or simply override everything _here_ in the plugin